### PR TITLE
RDK-44929: CPU Idle Metrics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,14 +20,14 @@ cmake_minimum_required(VERSION 3.10)
 project(MemCapture)
 
 # Add our local cmake directory to search for components
-set( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/cmake" )
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
 # The following disables an annoying warning "<blah> will change in GCC X.XX"
 add_compile_options(-Wno-psabi)
 add_compile_options(-Wall -Wextra)
 
 find_package(Threads REQUIRED)
-find_package(Breakpad QUIET )
+find_package(Breakpad QUIET)
 
 find_package(nlohmann_json CONFIG REQUIRED)
 find_package(inja CONFIG REQUIRED)
@@ -47,34 +47,40 @@ add_executable(${PROJECT_NAME}
 
         ProcessMetric.cpp
         MemoryMetric.cpp
-        )
+        CpuIdleMetric.cpp
+)
 
-set_property( SOURCE main.cpp
-        APPEND PROPERTY OBJECT_DEPENDS "${CMAKE_CURRENT_LIST_DIR}/templates/template.html" )
+set_property(SOURCE main.cpp
+        APPEND PROPERTY OBJECT_DEPENDS "${CMAKE_CURRENT_LIST_DIR}/templates/template.html")
 
 set_target_properties(${PROJECT_NAME} PROPERTIES
         CXX_STANDARD 17
-        )
+)
 
 target_include_directories(${PROJECT_NAME}
         PRIVATE
         3rdparty
         .
-        )
+)
 
 target_link_libraries(${PROJECT_NAME}
         Threads::Threads
         nlohmann_json::nlohmann_json
         pantor::inja
-        )
+)
 
-if(BREAKPAD_FOUND)
-        message(STATUS "Enabling breakpad support")
-        add_definitions( -DUSE_BREAKPAD )
+if (BREAKPAD_FOUND)
+    message(STATUS "Enabling breakpad support")
+    add_definitions(-DUSE_BREAKPAD)
 
-        target_link_libraries(${PROJECT_NAME}
-                Breakpad::BreakpadWrapper
-        )
-else()
-        message(STATUS "Breakpad not found")
-endif()
+    target_link_libraries(${PROJECT_NAME}
+            Breakpad::BreakpadWrapper
+    )
+else ()
+    message(STATUS "Breakpad not found")
+endif ()
+
+option(ENABLE_CPU_IDLE_METRICS "Enable support for kernel-based AV metrics on supported platforms" OFF)
+if (ENABLE_CPU_IDLE_METRICS)
+    add_definitions(-DENABLE_CPU_IDLE_METRICS=1)
+endif ()

--- a/CpuIdleMetric.cpp
+++ b/CpuIdleMetric.cpp
@@ -1,6 +1,21 @@
-//
-// Created by Stephen F on 14/11/23.
-//
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2023 Sky UK
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 
 #ifdef ENABLE_CPU_IDLE_METRICS
 

--- a/CpuIdleMetric.cpp
+++ b/CpuIdleMetric.cpp
@@ -1,0 +1,65 @@
+//
+// Created by Stephen F on 14/11/23.
+//
+
+#ifdef ENABLE_CPU_IDLE_METRICS
+
+#include "CpuIdleMetric.h"
+#include "Log.h"
+#include "Procrank.h"
+#include <sys/prctl.h>
+
+
+CpuIdleMetric::CpuIdleMetric(std::shared_ptr<JsonReportGenerator> reportGenerator) :
+        mReportGenerator(std::move(reportGenerator)),
+        mIdleMetrics({})
+{
+
+}
+
+
+void CpuIdleMetric::StartCollection([[maybe_unused]] const std::chrono::seconds frequency)
+{
+    // Check if collectd is running in the background. If it is, it might interfere with the stat collection since
+    // the idle metrics are globally scoped
+    LOG_INFO("Starting CPU idle metric collection");
+
+    Procrank procrank;
+    auto runningProcesses = procrank.GetMemoryUsage();
+
+    auto collectRunning = std::any_of(runningProcesses.begin(), runningProcesses.end(),
+                                      [](const Procrank::ProcessMemoryUsage &proc)
+                                      {
+                                          return proc.process.name().find("collectd") != std::string::npos;
+                                      });
+
+    if (collectRunning) {
+        LOG_WARN("*** WARNING:: Collectd is running in the background. This may cause incorrect CPU idle readings ***");
+    }
+
+    // Start by resetting the stats
+    auto ret = prctl(PR_GET_IDLE_METRICS, &mIdleMetrics, IDLE_METRICS_VERSION_V2, 0, 0);
+    if (ret != 0) {
+        LOG_ERROR("Failed to reset idle stats with error %d (%s)", ret, strerror(errno));
+    }
+
+    // Nothing to do now until we stop collection
+}
+
+void CpuIdleMetric::StopCollection()
+{
+    // Get the latest stats
+    LOG_INFO("Stopping CPU idle metric collection");
+    auto ret = prctl(PR_GET_IDLE_METRICS, &mIdleMetrics, IDLE_METRICS_VERSION_V2, 0, 0);
+    if (ret != 0)
+    {
+        LOG_ERROR("Failed to get idle stats with error %d (%s)", ret, strerror(errno));
+    }
+}
+
+void CpuIdleMetric::SaveResults()
+{
+    mReportGenerator->addCpuIdleMetrics(mIdleMetrics);
+}
+
+#endif

--- a/CpuIdleMetric.h
+++ b/CpuIdleMetric.h
@@ -1,0 +1,43 @@
+//
+// Created by Stephen F on 14/11/23.
+//
+
+#pragma once
+
+#ifdef ENABLE_CPU_IDLE_METRICS
+
+#include "IMetric.h"
+#include "JsonReportGenerator.h"
+#include <chrono>
+#include <memory>
+#include <thread>
+#include <condition_variable>
+#include <mutex>
+#include "Platform.h"
+#include <sys/prctl.h>
+
+/**
+ * @brief On supported platforms, retrieve the CPU idle metrics. Requires kernel patch.
+ *
+ * Only enabled when MemCapture built with ENABLE_CPU_IDLE_METRICS set
+ */
+class CpuIdleMetric : public IMetric
+{
+public:
+    CpuIdleMetric(std::shared_ptr<JsonReportGenerator> reportGenerator);
+
+    ~CpuIdleMetric() override = default;
+
+    void StartCollection(std::chrono::seconds frequency) override;
+
+    void StopCollection() override;
+
+    void SaveResults() override;
+
+private:
+    const std::shared_ptr<JsonReportGenerator> mReportGenerator;
+
+    IDLE_METRICS_V2 mIdleMetrics;
+};
+
+#endif

--- a/CpuIdleMetric.h
+++ b/CpuIdleMetric.h
@@ -1,6 +1,21 @@
-//
-// Created by Stephen F on 14/11/23.
-//
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2023 Sky UK
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 
 #pragma once
 

--- a/IMetric.h
+++ b/IMetric.h
@@ -28,6 +28,8 @@
 class IMetric
 {
 public:
+    virtual ~IMetric() = default;
+
     /**
      * @brief Start collecting data every X seconds and store the results in memory
      *

--- a/JsonReportGenerator.cpp
+++ b/JsonReportGenerator.cpp
@@ -19,6 +19,7 @@
 
 
 #include "JsonReportGenerator.h"
+#include "Log.h"
 
 #include <utility>
 
@@ -28,6 +29,7 @@ JsonReportGenerator::JsonReportGenerator(std::shared_ptr<Metadata> metadata,
 {
     mJson["processes"] = nlohmann::json::array();
     mJson["metadata"] = {};
+    mJson["cpuIdleStats"] = nullptr;
 
     mJson["grandTotal"]["linuxUsage"] = 0.0;
     mJson["grandTotal"]["calculatedUsage"] = 0.0;
@@ -55,7 +57,7 @@ void JsonReportGenerator::addDataset(const std::string &name, const std::vector<
     for (const auto& item : data) {
         nlohmann::json tmp;
 
-        for (const auto& value : item) {
+        for (const auto &value: item) {
             std::visit(overload{
                     [&](const std::pair<std::string, std::string> &v)
                     {
@@ -90,12 +92,12 @@ void JsonReportGenerator::addDataset(const std::string &name, const std::vector<
 nlohmann::json JsonReportGenerator::getJson()
 {
     mJson["metadata"] = {
-            {"image",     mMetadata->Image()},
-            {"platform",  mMetadata->Platform()},
-            {"mac",       mMetadata->Mac()},
-            {"timestamp", mMetadata->ReportTimestamp()},
-            {"duration",  mMetadata->Duration()},
-            {"swapEnabled",  mMetadata->SwapEnabled()}
+            {"image",       mMetadata->Image()},
+            {"platform",    mMetadata->Platform()},
+            {"mac",         mMetadata->Mac()},
+            {"timestamp",   mMetadata->ReportTimestamp()},
+            {"duration",    mMetadata->Duration()},
+            {"swapEnabled", mMetadata->SwapEnabled()}
     };
 
     return mJson;
@@ -196,4 +198,51 @@ void JsonReportGenerator::addToAccumulatedMemoryUsage(long double valueKb)
     mJson["grandTotal"]["calculatedUsage"] = usage;
 }
 
+#ifdef ENABLE_CPU_IDLE_METRICS
+void JsonReportGenerator::addCpuIdleMetrics(const IDLE_METRICS_V2 &metrics)
+{
+    nlohmann::json idleMetricsJson;
 
+    unsigned long long totalRuntimeNs = metrics.metricEndTime - metrics.metricStartTime;
+
+    auto &loadStats = idleMetricsJson["loadStats"];
+
+    // Per CPU stats
+    unsigned long long idleTime = 0;
+    for (int i = 0; i < T962X3_NUM_CPUS; i++) {
+        // Convert ns to s
+        loadStats["cpu"][i]["idle"]["sum"] = metrics.idle[i].sum_idle_time / 1000000.0;
+        loadStats["cpu"][i]["idle"]["percent"] = (float)((float)metrics.idle[i].sum_idle_time / (float)(totalRuntimeNs / 1000.0)) * 100;
+        idleTime += metrics.idle[i].sum_idle_time;
+    }
+
+    // Summary
+    // ms
+    loadStats["overall"]["idle"]["sum"] = idleTime / 1000000.0;
+    loadStats["overall"]["load"]["sum"] = metrics.sum_all_cpus_running_time / 1000000.0;
+    loadStats["overall"]["load"]["count"] = metrics.count;
+    loadStats["overall"]["load"]["percent"] = (float)((float)metrics.sum_all_cpus_running_time / (float)totalRuntimeNs) * 100;
+
+
+    // Load times
+    unsigned long run_time_lt_1ms_count = metrics.count - (metrics.run_time_gt_1ms + metrics.run_time_gt_5ms +
+                                                            metrics.run_time_gt_10ms + metrics.run_time_gt_20ms +
+                                                            metrics.run_time_gt_30ms + metrics.run_time_gt_40ms +
+                                                            metrics.run_time_gt_50ms + metrics.run_time_gt_75ms +
+                                                            metrics.run_time_gt_100ms);
+
+    // Store the amount of times the CPU was under load for the specified duration
+    loadStats["load"]["lt1ms"] = run_time_lt_1ms_count;          // < 1ms
+    loadStats["load"]["gt1ms"] = metrics.run_time_gt_1ms;       // >= 1ms && < 5ms
+    loadStats["load"]["gt5ms"] = metrics.run_time_gt_5ms;       // >= 5ms && < 10ms
+    loadStats["load"]["gt10ms"] = metrics.run_time_gt_10ms;     // >= 10ms && < 20 ms
+    loadStats["load"]["gt20ms"] = metrics.run_time_gt_20ms;     // >= 20ms && < 30 ms
+    loadStats["load"]["gt30ms"] = metrics.run_time_gt_30ms;     // >= 30ms && < 40 ms
+    loadStats["load"]["gt40ms"] = metrics.run_time_gt_40ms;     // >= 40ms && < 50 ms
+    loadStats["load"]["gt50ms"] = metrics.run_time_gt_50ms;     // >= 50ms && < 75 ms
+    loadStats["load"]["gt75ms"] = metrics.run_time_gt_75ms;     // >= 75ms && < 100 ms
+    loadStats["load"]["gt100ms"] = metrics.run_time_gt_100ms;    // >= 100ms
+
+    mJson["cpuIdleStats"] = loadStats;
+}
+#endif

--- a/JsonReportGenerator.h
+++ b/JsonReportGenerator.h
@@ -28,6 +28,10 @@
 #include "GroupManager.h"
 #include "Metadata.h"
 
+#ifdef ENABLE_CPU_IDLE_METRICS
+#include <sys/prctl.h>
+#endif
+
 template<class... Ts>
 struct overload : Ts ...
 {
@@ -47,6 +51,10 @@ public:
     void addDataset(const std::string& name, const std::vector<dataItems>& data);
 
     void addProcesses(std::vector<processMeasurement> &processes);
+
+#ifdef ENABLE_CPU_IDLE_METRICS
+    void addCpuIdleMetrics(const IDLE_METRICS_V2& metrics);
+#endif
 
     void setAverageLinuxMemoryUsage(int valueKb);
 

--- a/MemoryMetric.h
+++ b/MemoryMetric.h
@@ -37,7 +37,7 @@ class MemoryMetric : public IMetric
 public:
     MemoryMetric(Platform platform, std::shared_ptr<JsonReportGenerator> reportGenerator);
 
-    ~MemoryMetric();
+    ~MemoryMetric() override;
 
     void StartCollection(std::chrono::seconds frequency) override;
 

--- a/ProcessMetric.h
+++ b/ProcessMetric.h
@@ -32,9 +32,9 @@
 class ProcessMetric : public IMetric
 {
 public:
-    ProcessMetric(std::shared_ptr<JsonReportGenerator> reportGenerator);
+    explicit ProcessMetric(std::shared_ptr<JsonReportGenerator> reportGenerator);
 
-    ~ProcessMetric();
+    ~ProcessMetric() override;
 
     void StartCollection(std::chrono::seconds frequency) override;
 

--- a/templates/template.html
+++ b/templates/template.html
@@ -98,9 +98,11 @@
         <div class="col-6">
             <h2 class="title">Grand Totals (Average)</h2>
             <ul class="list-group">
-                <li class="list-group-item list-group-item-primary"><b>Linux Reported Used:</b> {{ round(grandTotal.linuxUsage, 2) }} MB
+                <li class="list-group-item list-group-item-primary"><b>Linux Reported Used:</b> {{
+                    round(grandTotal.linuxUsage, 2) }} MB
                 </li>
-                <li class="list-group-item list-group-item-primary"><b>PSS + GPU + CMA (+ BMEM):</b> {{ round(grandTotal.calculatedUsage, 2) }} MB
+                <li class="list-group-item list-group-item-primary"><b>PSS + GPU + CMA (+ BMEM):</b> {{
+                    round(grandTotal.calculatedUsage, 2) }} MB
                 </li>
             </ul>
         </div>
@@ -131,15 +133,15 @@
                     <th style="max-width: 5rem;">USS Max (KB)</th>
                     <th style="max-width: 5rem;">USS Avg (KB)</th>
                     {% if metadata.swapEnabled %}
-                        <th style="max-width: 5rem;">Swap Min (KB)</th>
-                        <th style="max-width: 5rem;">Swap Max (KB)</th>
-                        <th style="max-width: 5rem;">Swap Avg (KB)</th>
-                        <th style="max-width: 5rem;">Swap PSS Min (KB)</th>
-                        <th style="max-width: 5rem;">Swap PSS Max (KB)</th>
-                        <th style="max-width: 5rem;">Swap PSS Avg (KB)</th>
-                        <th style="max-width: 5rem;">ZRAM Swap Min (KB)</th>
-                        <th style="max-width: 5rem;">ZRAM Swap Max (KB)</th>
-                        <th style="max-width: 5rem;">ZRAM Swap Avg (KB)</th>
+                    <th style="max-width: 5rem;">Swap Min (KB)</th>
+                    <th style="max-width: 5rem;">Swap Max (KB)</th>
+                    <th style="max-width: 5rem;">Swap Avg (KB)</th>
+                    <th style="max-width: 5rem;">Swap PSS Min (KB)</th>
+                    <th style="max-width: 5rem;">Swap PSS Max (KB)</th>
+                    <th style="max-width: 5rem;">Swap PSS Avg (KB)</th>
+                    <th style="max-width: 5rem;">ZRAM Swap Min (KB)</th>
+                    <th style="max-width: 5rem;">ZRAM Swap Max (KB)</th>
+                    <th style="max-width: 5rem;">ZRAM Swap Avg (KB)</th>
                     {% endif %}
                 </tr>
                 </thead>
@@ -163,15 +165,15 @@
                     <td>{{ p.uss.max }}</td>
                     <td>{{ p.uss.average }}</td>
                     {% if metadata.swapEnabled %}
-                        <td>{{ p.swap.min }}</td>
-                        <td>{{ p.swap.max }}</td>
-                        <td>{{ p.swap.average }}</td>
-                        <td>{{ p.swapPss.min }}</td>
-                        <td>{{ p.swapPss.max }}</td>
-                        <td>{{ p.swapPss.average }}</td>
-                        <td>{{ p.swapZram.min }}</td>
-                        <td>{{ p.swapZram.max }}</td>
-                        <td>{{ p.swapZram.average }}</td>
+                    <td>{{ p.swap.min }}</td>
+                    <td>{{ p.swap.max }}</td>
+                    <td>{{ p.swap.average }}</td>
+                    <td>{{ p.swapPss.min }}</td>
+                    <td>{{ p.swapPss.max }}</td>
+                    <td>{{ p.swapPss.average }}</td>
+                    <td>{{ p.swapZram.min }}</td>
+                    <td>{{ p.swapZram.max }}</td>
+                    <td>{{ p.swapZram.average }}</td>
                     {% endif %}
                 </tr>
                 {% endfor %}
@@ -206,7 +208,7 @@
                     <thead>
                     <tr>
                         {% for item in dataset._columnOrder %}
-                            <th>{{ item }}</th>
+                        <th>{{ item }}</th>
                         {% endfor %}
                     </tr>
                     </thead>
@@ -214,7 +216,7 @@
                     {% for row in dataset.data %}
                     <tr>
                         {% for item in objectToArray(row, dataset._columnOrder) %}
-                            <td>{{ item }}</td>
+                        <td>{{ item }}</td>
                         {% endfor %}
                     </tr>
                     {% endfor %}
@@ -261,6 +263,64 @@
             {% endfor %}
         </div>
     </div>
+    {% if isObject(cpuIdleStats) %}
+    <div class="row mt-3">
+        <h3>CPU Load/Idle Measurements</h3>
+        <div class="row">
+            <div class="col-6">
+                <h5>Summary</h5>
+                <table class="table table-striped table-sm mt-3">
+                    <tbody>
+                    <tr>
+                        <td>Total amount of time under full load (ms)</td>
+                        <td>{{ round(cpuIdleStats.overall.load.sum, 2) }}</td>
+                    </tr>
+                    <tr>
+                        <td>Total amount of time idle (ms)</td>
+                        <td>{{ round(cpuIdleStats.overall.idle.sum, 2) }}</td>
+                    </tr>
+                    <tr>
+                        <td>Number of times under full load</td>
+                        <td>{{ cpuIdleStats.overall.load.count }}</td>
+                    </tr>
+                    <tr>
+                        <td>% of time spent under full load</td>
+                        <td>{{ round(cpuIdleStats.overall.load.percent, 2) }}%</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+
+            <div class="col-6">
+                <h5>Per CPU Stats</h5>
+                <table class="table table-striped table-sm">
+                    <thead>
+                    <tr>
+                        <th>CPU #</th>
+                        <th>Total time idle (ms)</th>
+                        <th>% time idle</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {% for cpu in cpuIdleStats.cpu %}
+                    <tr>
+                        <td>{{ loop.index }}</td>
+                        <td>{{ round(cpu.idle.sum, 2) }}</td>
+                        <td>{{ round(cpu.idle.percent, 2) }}%</td>
+                    </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        <div class="row">
+            <h5>Full Load Timings</h5>
+            <p>This chart shows how often a CPU was under full load for the given duration. On a heavily loaded system, this graph will skew to the right - indicating the CPU was spending longer durations under full load</p>
+            <canvas id="loadChart"></canvas>
+        </div>
+    </div>
+    {% endif %}
+
 </div>
 
 <script>
@@ -325,7 +385,55 @@
 
     const pssChartCtx = document.getElementById('pssChart');
     const pssGroupChartCtx = document.getElementById('pssGroupChart');
+    const loadChartCtx = document.getElementById('loadChart');
 
+    {% if isObject(cpuIdleStats) %}
+    new Chart(loadChartCtx, {
+       type: 'bar',
+        options: {
+           scales: {
+               y: {
+                   type: 'logarithmic',
+                   text: "Count"
+               },
+               x: {
+                   text: "Duration"
+               }
+           }
+        },
+        data: {
+           labels: [
+               "<1ms",
+               ">=1ms && <5ms",
+               ">=5ms && <10ms",
+               ">=10ms && <20ms",
+               ">=20ms && <30ms",
+               ">=30ms && <40ms",
+               ">=40ms && <50ms",
+               ">=50ms && <75ms",
+               ">=75ms && <100ms",
+               ">=100ms",
+           ],
+           datasets: [
+               {
+                   label: "Number of times under load",
+                   data: [
+                        {{ cpuIdleStats.load.lt1ms }},
+                        {{ cpuIdleStats.load.gt1ms }},
+                        {{ cpuIdleStats.load.gt5ms }},
+                        {{ cpuIdleStats.load.gt10ms }},
+                        {{ cpuIdleStats.load.gt20ms }},
+                        {{ cpuIdleStats.load.gt30ms }},
+                        {{ cpuIdleStats.load.gt40ms }},
+                        {{ cpuIdleStats.load.gt50ms }},
+                        {{ cpuIdleStats.load.gt75ms }},
+                        {{ cpuIdleStats.load.gt100ms }}
+                  ]
+               }
+           ]
+        }
+    });
+    {% endif %}
 
     new Chart(pssChartCtx, {
         type: 'bar',


### PR DESCRIPTION
Add support for CPU Idle Metrics. 

Has a requirement on the CPU idle metrics kernel patch. MemCapture must be built with `-DENABLE_CPU_IDLE_METRICS=ON` to enable support, and use the `--cpuidle` command-line argument at runtime.