### PR TITLE
RDKEMW-14121 : Added Mediatek Platform support in Memcapture Code 

### DIFF
--- a/MemoryMetric.h
+++ b/MemoryMetric.h
@@ -69,8 +69,6 @@ private:
     
     void GetGpuMemoryUsageMediatek();
 
-    void GetGpuMemoryUsageMediatek();
-
     void GetGpuMemoryUsageRealtek();
 
     pid_t tidToParentPid(pid_t tid);


### PR DESCRIPTION
Reason of Change: removed the reduntant GetGpuMemoryUsageMediatek function to avoid the MTk build compilation error